### PR TITLE
Make testConfigurationIsNotARegularFile isolated

### DIFF
--- a/java/BasicTest.java
+++ b/java/BasicTest.java
@@ -106,7 +106,7 @@ public class BasicTest {
 
 	@Test(timeout = 3000)
 	public void testConfigurationIsNotARegularFile() throws Exception {
-		File folder = tempFolder.newFolder();
+		File folder = tempFolder.newFolder("simple.cfg");
 		Map<String, Object> result = MinesweeperTestUtils.execute(folder, Collections.emptyList());
 		int exitCode = (Integer) result.get("exitCode");
 


### PR DESCRIPTION
Use a valid file name as folder name for `BasicTest.testConfigurationIsNotARegularFile`.
Described in: https://github.com/se2p/ps-wise-2021-public-tests/issues/12